### PR TITLE
Mejoras para uso offline

### DIFF
--- a/lib/screens/argentina_download_screen.dart
+++ b/lib/screens/argentina_download_screen.dart
@@ -687,9 +687,11 @@ class _ArgentinaDownloadScreenState extends State<ArgentinaDownloadScreen> {
                   }
                 },
             );
+            // Tras una descarga exitosa de la provincia, limitar la sesión al maxZoom del area creada
+            // 'area' está en alcance aquí porque fue creado arriba en este bloque.
+            _mapCacheService.setSessionMaxZoom(area.maxZoom);
+            if (kDebugMode) debugPrint('CICLE-UI: session max zoom set to ${area.maxZoom} for ${province.name}');
           }
-            // Tras una descarga exitosa de la provincia, limitar la sesión a maxZoom=14
-            MapCacheService().setSessionMaxZoom(14);
           
           completedProvinces++;
           if (kDebugMode) debugPrint('Completed province: ${province.name}');


### PR DESCRIPTION
Se actualiza la lógica para configurar el nivel máximo de zoom de la sesión tras la descarga correcta de una provincia en `ArgentinaDownloadScreen`. En lugar de limitar siempre la sesión a un nivel de zoom fijo, el código ahora configura dinámicamente el zoom máximo según las propiedades del área descargada.

Gestión del zoom de la sesión del mapa:

* Tras la descarga correcta de una provincia, el zoom máximo de la sesión ahora se establece en `area.maxZoom` (el zoom máximo del área descargada), en lugar de estar siempre predeterminado en 14. Esto garantiza que los usuarios puedan ampliar tanto como lo permitan los datos de cada provincia.
* Se añadió una declaración de impresión de depuración para registrar el nuevo zoom máximo de la sesión y el nombre de la provincia para facilitar la resolución de problemas y la verificación durante el desarrollo.